### PR TITLE
Set up Dependabot for Maven dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  # Maven: Parent project
+  - package-ecosystem: "maven"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    commit-message:
+      prefix: "deps"


### PR DESCRIPTION
Configured Dependabot to update Maven dependencies weekly with a limit on open pull requests.