### PR TITLE
feat: add GraphQL support for provider search (#60)

### DIFF
--- a/terrakube-client/src/main/java/io/terrakube/client/TerrakubeClient.java
+++ b/terrakube-client/src/main/java/io/terrakube/client/TerrakubeClient.java
@@ -7,6 +7,7 @@ import io.terrakube.client.model.graphql.GraphQLRequest;
 import io.terrakube.client.model.graphql.GraphQLResponse;
 import io.terrakube.client.model.graphql.queries.search.module.SearchOrganizationModuleResponse;
 import io.terrakube.client.model.graphql.queries.search.organization.SearchOrganizationResponse;
+import io.terrakube.client.model.graphql.queries.search.provider.SearchOrganizationProviderResponse;
 import io.terrakube.client.model.organization.Organization;
 import io.terrakube.client.model.organization.job.Job;
 import io.terrakube.client.model.organization.job.JobRequest;
@@ -130,4 +131,8 @@ public interface TerrakubeClient {
     @RequestLine("POST /graphql/api/v1")
     @Headers("Content-Type: application/json")
     GraphQLResponse<SearchOrganizationModuleResponse> searchOrganizationModules(GraphQLRequest request);
+
+    @RequestLine("POST /graphql/api/v1")
+    @Headers("Content-Type: application/json")
+    GraphQLResponse<SearchOrganizationProviderResponse> searchOrganizationProviders(GraphQLRequest request);
 }

--- a/terrakube-client/src/main/java/io/terrakube/client/model/graphql/queries/search/provider/Implementation.java
+++ b/terrakube-client/src/main/java/io/terrakube/client/model/graphql/queries/search/provider/Implementation.java
@@ -1,0 +1,20 @@
+package io.terrakube.client.model.graphql.queries.search.provider;
+
+import lombok.Data;
+
+@Data
+public class Implementation {
+    private String id;
+    private String os;
+    private String arch;
+    private String filename;
+    private String downloadUrl;
+    private String shasumsUrl;
+    private String shasumsSignatureUrl;
+    private String shasum;
+    private String keyId;
+    private String asciiArmor;
+    private String trustSignature;
+    private String source;
+    private String sourceUrl;
+}

--- a/terrakube-client/src/main/java/io/terrakube/client/model/graphql/queries/search/provider/ImplementationConnection.java
+++ b/terrakube-client/src/main/java/io/terrakube/client/model/graphql/queries/search/provider/ImplementationConnection.java
@@ -1,0 +1,9 @@
+package io.terrakube.client.model.graphql.queries.search.provider;
+
+import lombok.Data;
+import java.util.List;
+
+@Data
+public class ImplementationConnection {
+    private List<ImplementationEdge> edges;
+}

--- a/terrakube-client/src/main/java/io/terrakube/client/model/graphql/queries/search/provider/ImplementationEdge.java
+++ b/terrakube-client/src/main/java/io/terrakube/client/model/graphql/queries/search/provider/ImplementationEdge.java
@@ -1,0 +1,8 @@
+package io.terrakube.client.model.graphql.queries.search.provider;
+
+import lombok.Data;
+
+@Data
+public class ImplementationEdge {
+    private Implementation node;
+}

--- a/terrakube-client/src/main/java/io/terrakube/client/model/graphql/queries/search/provider/Organization.java
+++ b/terrakube-client/src/main/java/io/terrakube/client/model/graphql/queries/search/provider/Organization.java
@@ -1,0 +1,10 @@
+package io.terrakube.client.model.graphql.queries.search.provider;
+
+import lombok.Data;
+
+@Data
+public class Organization {
+    private String id;
+    private String name;
+    private ProviderConnection provider;
+}

--- a/terrakube-client/src/main/java/io/terrakube/client/model/graphql/queries/search/provider/OrganizationConnection.java
+++ b/terrakube-client/src/main/java/io/terrakube/client/model/graphql/queries/search/provider/OrganizationConnection.java
@@ -1,0 +1,9 @@
+package io.terrakube.client.model.graphql.queries.search.provider;
+
+import lombok.Data;
+import java.util.List;
+
+@Data
+public class OrganizationConnection {
+    private List<OrganizationEdge> edges;
+}

--- a/terrakube-client/src/main/java/io/terrakube/client/model/graphql/queries/search/provider/OrganizationEdge.java
+++ b/terrakube-client/src/main/java/io/terrakube/client/model/graphql/queries/search/provider/OrganizationEdge.java
@@ -1,0 +1,8 @@
+package io.terrakube.client.model.graphql.queries.search.provider;
+
+import lombok.Data;
+
+@Data
+public class OrganizationEdge {
+    private Organization node;
+}

--- a/terrakube-client/src/main/java/io/terrakube/client/model/graphql/queries/search/provider/Provider.java
+++ b/terrakube-client/src/main/java/io/terrakube/client/model/graphql/queries/search/provider/Provider.java
@@ -1,0 +1,10 @@
+package io.terrakube.client.model.graphql.queries.search.provider;
+
+import lombok.Data;
+
+@Data
+public class Provider {
+    private String id;
+    private String name;
+    private VersionConnection version;
+}

--- a/terrakube-client/src/main/java/io/terrakube/client/model/graphql/queries/search/provider/ProviderConnection.java
+++ b/terrakube-client/src/main/java/io/terrakube/client/model/graphql/queries/search/provider/ProviderConnection.java
@@ -1,0 +1,9 @@
+package io.terrakube.client.model.graphql.queries.search.provider;
+
+import lombok.Data;
+import java.util.List;
+
+@Data
+public class ProviderConnection {
+    private List<ProviderEdge> edges;
+}

--- a/terrakube-client/src/main/java/io/terrakube/client/model/graphql/queries/search/provider/ProviderEdge.java
+++ b/terrakube-client/src/main/java/io/terrakube/client/model/graphql/queries/search/provider/ProviderEdge.java
@@ -1,0 +1,8 @@
+package io.terrakube.client.model.graphql.queries.search.provider;
+
+import lombok.Data;
+
+@Data
+public class ProviderEdge {
+    private Provider node;
+}

--- a/terrakube-client/src/main/java/io/terrakube/client/model/graphql/queries/search/provider/SearchOrganizationProviderResponse.java
+++ b/terrakube-client/src/main/java/io/terrakube/client/model/graphql/queries/search/provider/SearchOrganizationProviderResponse.java
@@ -1,0 +1,8 @@
+package io.terrakube.client.model.graphql.queries.search.provider;
+
+import lombok.Data;
+
+@Data
+public class SearchOrganizationProviderResponse {
+    private OrganizationConnection organization;
+}

--- a/terrakube-client/src/main/java/io/terrakube/client/model/graphql/queries/search/provider/Version.java
+++ b/terrakube-client/src/main/java/io/terrakube/client/model/graphql/queries/search/provider/Version.java
@@ -1,0 +1,12 @@
+package io.terrakube.client.model.graphql.queries.search.provider;
+
+import lombok.Data;
+import java.util.List;
+
+@Data
+public class Version {
+    private String id;
+    private String versionNumber;
+    private String protocols;
+    private ImplementationConnection implementation;
+}

--- a/terrakube-client/src/main/java/io/terrakube/client/model/graphql/queries/search/provider/VersionConnection.java
+++ b/terrakube-client/src/main/java/io/terrakube/client/model/graphql/queries/search/provider/VersionConnection.java
@@ -1,0 +1,9 @@
+package io.terrakube.client.model.graphql.queries.search.provider;
+
+import lombok.Data;
+import java.util.List;
+
+@Data
+public class VersionConnection {
+    private List<VersionEdge> edges;
+}

--- a/terrakube-client/src/main/java/io/terrakube/client/model/graphql/queries/search/provider/VersionEdge.java
+++ b/terrakube-client/src/main/java/io/terrakube/client/model/graphql/queries/search/provider/VersionEdge.java
@@ -1,0 +1,8 @@
+package io.terrakube.client.model.graphql.queries.search.provider;
+
+import lombok.Data;
+
+@Data
+public class VersionEdge {
+    private Version node;
+}


### PR DESCRIPTION
- Added GraphQL models for providers, versions, implementations, and organizations.
- Introduced `searchOrganizationProviders` method in TerrakubeClient.