### PR TITLE
feat: bump project version to 1.5.0 and add token refresh support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
     <packaging>pom</packaging>
 
     <properties>
-        <revision>1.2.0</revision>
+        <revision>1.5.0</revision>
         <maven.deploy.skip>true</maven.deploy.skip>
         <sonar.organization>azbuilder</sonar.organization>
         <sonar.host.url>https://sonarcloud.io</sonar.host.url>

--- a/terrakube-client/pom.xml
+++ b/terrakube-client/pom.xml
@@ -20,7 +20,7 @@
 		<maven-source-plugin.version>3.3.1</maven-source-plugin.version>
 		<maven-javadoc-plugin.version>3.12.0</maven-javadoc-plugin.version>
 		<maven-gpg-plugin.version>3.2.8</maven-gpg-plugin.version>
-		<revision>1.2.0</revision>
+		<revision>1.5.0</revision>
 		<feign.version>13.6</feign.version>
 		<feign-form.version>3.8.0</feign-form.version>
 		<maven.deploy.skip>false</maven.deploy.skip>

--- a/terrakube-client/src/main/java/io/terrakube/client/TerrakubeClient.java
+++ b/terrakube-client/src/main/java/io/terrakube/client/TerrakubeClient.java
@@ -26,6 +26,7 @@ import io.terrakube.client.model.organization.vcs.github_app_token.GitHubAppToke
 import io.terrakube.client.model.organization.workspace.Workspace;
 import io.terrakube.client.model.organization.workspace.history.HistoryRequest;
 import io.terrakube.client.model.organization.workspace.variable.Variable;
+import io.terrakube.client.model.refresh.RefreshTokenRequest;
 import io.terrakube.client.model.response.Response;
 import io.terrakube.client.model.response.ResponseWithInclude;
 
@@ -135,4 +136,8 @@ public interface TerrakubeClient {
     @RequestLine("POST /graphql/api/v1")
     @Headers("Content-Type: application/json")
     GraphQLResponse<SearchOrganizationProviderResponse> searchOrganizationProviders(GraphQLRequest request);
+
+    @RequestLine("POST /refresh-token/v1/vcs")
+    @Headers("Content-Type: application/json")
+    GraphQLResponse<SearchOrganizationProviderResponse> refreshToken(RefreshTokenRequest request);
 }

--- a/terrakube-client/src/main/java/io/terrakube/client/model/refresh/RefreshTokenRequest.java
+++ b/terrakube-client/src/main/java/io/terrakube/client/model/refresh/RefreshTokenRequest.java
@@ -1,0 +1,8 @@
+package io.terrakube.client.model.refresh;
+
+import lombok.Data;
+
+@Data
+public class RefreshTokenRequest {
+    private String gitPath;
+}

--- a/terrakube-spring-boot-autoconfigure/pom.xml
+++ b/terrakube-spring-boot-autoconfigure/pom.xml
@@ -21,7 +21,7 @@
 		<maven-javadoc-plugin.version>3.12.0</maven-javadoc-plugin.version>
 		<maven-gpg-plugin.version>3.2.8</maven-gpg-plugin.version>
 		<feign.version>13.6</feign.version>
-		<revision>1.2.0</revision>
+		<revision>1.5.0</revision>
 		<maven.deploy.skip>false</maven.deploy.skip>
 		<lombok.version>1.18.42</lombok.version>
 	</properties>

--- a/terrakube-spring-boot-starter-sample/pom.xml
+++ b/terrakube-spring-boot-starter-sample/pom.xml
@@ -19,7 +19,7 @@
 		<maven-source-plugin.version>3.3.1</maven-source-plugin.version>
 		<maven-javadoc-plugin.version>3.12.0</maven-javadoc-plugin.version>
 		<maven-gpg-plugin.version>3.2.8</maven-gpg-plugin.version>
-		<revision>1.2.0</revision>
+		<revision>1.5.0</revision>
 		<maven.deploy.skip>true</maven.deploy.skip>
 	</properties>
 

--- a/terrakube-spring-boot-starter/pom.xml
+++ b/terrakube-spring-boot-starter/pom.xml
@@ -17,7 +17,7 @@
     <maven-source-plugin.version>3.3.1</maven-source-plugin.version>
     <maven-javadoc-plugin.version>3.12.0</maven-javadoc-plugin.version>
     <maven-gpg-plugin.version>3.2.8</maven-gpg-plugin.version>
-    <revision>1.2.0</revision>
+    <revision>1.5.0</revision>
     <maven.deploy.skip>false</maven.deploy.skip>
   </properties>
 


### PR DESCRIPTION
- Updated project `revision` to 1.5.0 across all modules.
- Introduced `refreshToken` method in `TerrakubeClient`.
- Added `RefreshTokenRequest` model.